### PR TITLE
Fix connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ### Home Assistant
 
 1. Go to the integrations page
-1. Click on the éAdd Integration" button at the bottom-right
+1. Click on the "Add Integration" button at the bottom-right
 1. Search for the "OpenRGB" integration
 1. Select the OpenRGB integration
 

--- a/custom_components/openrgb/__init__.py
+++ b/custom_components/openrgb/__init__.py
@@ -121,7 +121,7 @@ async def async_setup_entry(hass, entry):
     def connection_failed():
         autolog("<<<")
         if hass.data[DOMAIN]["online"]:
-            hass.data[DOMAIN][ORGB_DATA].comms.stop_connection()
+            hass.data[DOMAIN][ORGB_DATA].disconnect()
             _LOGGER.info(
                 "Connection lost to OpenRGB SDK Server at %s:%i",
                 config[CONF_HOST],
@@ -191,7 +191,7 @@ async def async_setup_entry(hass, entry):
         if not hass.data[DOMAIN]["online"]:
             # try to reconnect
             try:
-                hass.data[DOMAIN][ORGB_DATA].comms.start_connection()
+                hass.data[DOMAIN][ORGB_DATA].connect()
                 hass.data[DOMAIN]["connection_recovered"]()
             except OSError:
                 hass.data[DOMAIN]["connection_failed"]()
@@ -256,7 +256,7 @@ async def async_unload_entry(hass, entry):
         hass.data[DOMAIN][ENTRY_IS_SETUP] = set()
         hass.data[DOMAIN][ORGB_TRACKER]()
         hass.data[DOMAIN][ORGB_TRACKER] = None
-        hass.data[DOMAIN][ORGB_DATA].comms.stop_connection()
+        hass.data[DOMAIN][ORGB_DATA].disconnect()
         hass.data[DOMAIN][ORGB_DATA] = None
         hass.data[DOMAIN]["unlistener"]()
         hass.services.async_remove(DOMAIN, SERVICE_FORCE_UPDATE)

--- a/custom_components/openrgb/__init__.py
+++ b/custom_components/openrgb/__init__.py
@@ -176,14 +176,18 @@ async def async_setup_entry(hass, entry):
 
     def _get_updated_devices():
         autolog("<<<")
-        try:
-            orgb.update()
-        except OSError:
-            autolog(">>>exception")
+        if hass.data[DOMAIN]["online"]:
+            try:
+                orgb.update()
+                return orgb.devices
+            except OSError:
+                autolog(">>>exception")
+                hass.data[DOMAIN]["connection_failed"]()
+                return None
+        else:
             hass.data[DOMAIN]["connection_failed"]()
             return None
         autolog(">>>")
-        return orgb.devices
 
     await async_load_devices(_get_updated_devices())
 

--- a/custom_components/openrgb/translations/ru.json
+++ b/custom_components/openrgb/translations/ru.json
@@ -1,0 +1,47 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Интеграция уже создана ранее",
+            "conn_error": "Ошибка подключения к OpenRGB серверу"
+        },
+        "error": {
+            "cannot_connect": "Ошибка подключения",
+            "unknown": "Неизвестная ошибка"
+        },
+        "flow_title": "Настройка OpenRGB",
+        "step": {
+            "user": {
+                "data": {
+                    "client_id": "Client ID",
+                    "host": "Хост",
+                    "port": "Порт"
+                },
+                "description": "Укажите параметры подключения к OpenRGB серверу",
+                "title": "OpenRGB"
+            }
+        }
+    },
+    "options": {
+        "abort": {
+            "already_configured": "Интеграция уже создана ранее",
+            "conn_error": "Ошибка подключения к OpenRGB серверу"
+        },
+        "error": {
+            "cannot_connect": "Ошибка подключения",
+            "unknown": "Неизвестная ошибка"
+        },
+        "flow_title": "Настройка OpenRGB",
+        "step": {
+            "user": {
+                "data": {
+                    "client_id": "Client ID",
+                    "host": "Хост",
+                    "port": "Порт"
+                },
+                "description": "Укажите параметры подключения к OpenRGB серверу",
+                "title": "OpenRGB"
+            }
+        }
+    },
+    "title": "OpenRGB"
+}


### PR DESCRIPTION
Hello. Thanks for adding the component to HACS. Someone had to do it =)

I ran into a problem: if you restart the OpenRGB server, the component cannot connect itself back to the server.

I tried to correct this situation as much as I could.

The PR adds a check for connecting to the server when updating devices. In this case, it becomes possible to reconnect.