### PR TITLE
small bug fixes

### DIFF
--- a/custom_components/openrgb/light.py
+++ b/custom_components/openrgb/light.py
@@ -251,8 +251,8 @@ class OpenRGBDevice(OpenRGBLight):
         self._attr_unique_id = f'{ha_dev_unique_id}_{unique_id}'
         self._name = self._retrieve_current_name()
 
-        self._brightness = 100.0
-        self._prev_brightness = 100.0
+        self._brightness = 255.0
+        self._prev_brightness = 255.0
 
         self._hs_value = (0.0, 0.0)
         self._prev_hs_value = (0.0, 0.0)
@@ -350,8 +350,8 @@ class OpenRGBLed(OpenRGBLight):
         self._name = self._retrieve_current_name()
         _LOGGER.debug ("led name: %s", self._name)
 
-        self._brightness = 100.0
-        self._prev_brightness = 100.0
+        self._brightness = 255.0
+        self._prev_brightness = 255.0
 
         self._hs_value = (0.0, 0.0)
         self._prev_hs_value = (0.0, 0.0)

--- a/custom_components/openrgb/light.py
+++ b/custom_components/openrgb/light.py
@@ -175,6 +175,10 @@ class OpenRGBLight(LightEntity):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
+        # prevent subsequent turn_off calls from erasing the previous state
+        if not self.is_on:
+            return
+            
         # preserve the state
         self._prev_brightness = self._brightness
         self._prev_hs_value = self._hs_value


### PR DESCRIPTION
Just some fixes to 2 small problems I've had.

1. Fixes the overwriting of the state when turning off an already-off device.
    This situation commonly happens when turning off a device that is part of a group, then turning off the group.

2. Changes the brightness setting initial configuration from 39% to 100%.
    Not sure if 39% was intentional or there was a mix-up between ATTR_BRIGHTNESS and ATTR_BRIGHTNESS_PCT, where 100.0 is 
    the max value.